### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ To open the notebooks shares please install the below software.
 After the installation of the package,
 go to your start bar in your taskbar.
 look for anaconda prompt
+[![Run on Repl.it](https://repl.it/badge/github/poornachandrakashi/codeon)](https://repl.it/github/poornachandrakashi/codeon)
 
 Type git clone https://github.com/poornachandrakashi/Christacademy/edit/master/README.md
 in the prompt


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).